### PR TITLE
feat: add generic release alert github action

### DIFF
--- a/workflows/release-alert.yml
+++ b/workflows/release-alert.yml
@@ -1,0 +1,44 @@
+# This is a basic workflow to help you get started with Actions
+name: ReleaseAlert
+
+# Controls when the workflow will run
+on:
+  workflow_call:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "alert"
+  alert:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Dump Github context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Slack Notification on SUCCESS
+        if: success()
+        uses: tokorom/action-slack-incoming-webhook@main
+        env:
+          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          text: A release is published.
+          blocks: |
+            [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<${{ github.event.release.html_url }}|${{ github.event.release.tag_name}}>"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ${{ toJSON(github.event.release.body) }}
+                }
+              }
+            ]


### PR DESCRIPTION
### Context + Solution

Au lieu de copier / coller un `release-alert.yml` dans chaque repository, on le met ici en tant que `reusable workflow` et on l'importe dans les repositories concernés.
