### PR TITLE
feat: add app center deployments workflows INSTRUCTOR-2098

### DIFF
--- a/workflows/createAppCenterDeployments.yml
+++ b/workflows/createAppCenterDeployments.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm install -g appcenter-cli
       - name: Create iOS codepush deployment
         run: |
-          appcenter codepush deployment add --token "$INPUT_APPCENTER-IOS-API-TOKEN" -a "$INPUT_APPCENTER-IOS-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
+          appcenter codepush deployment add --token "${{ github.event.inputs.appcenter-ios-api-token }}" -a "Ornikar/${{ github.event.inputs.appcenter-ios-app-name }}"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
       - name: Create Android codepush deployment
         run: |
-          appcenter codepush deployment add --token "$INPUT_APPCENTER-ANDROID-API-TOKEN" -a "$INPUT_APPCENTER-ANDROID-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
+          appcenter codepush deployment add --token "${{ github.event.inputs.appcenter-android-api-token }}" -a "Ornikar/${{ github.event.inputs.appcenter-android-app-name }}"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')

--- a/workflows/createAppCenterDeployments.yml
+++ b/workflows/createAppCenterDeployments.yml
@@ -1,0 +1,37 @@
+name: create-app-center-deployments
+run-name: Create AppCenter deployments for this PR
+
+on:
+  workflow_call:
+
+inputs:
+  appcenter-android-api-token:
+    description: 'AppCenter Android API Token'
+    required: true
+  appcenter-ios-api-token:
+    description: 'AppCenter iOS API Token'
+    required: true
+  appcenter-android-app-name:
+    description: 'AppCenter Android App Name'
+    required: true
+  appcenter-ios-app-name:
+    description: 'AppCenter iOS App Name'
+    required: true
+
+jobs:
+  create-app-center-deployments:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install -g appcenter-cli
+      - name: Create iOS codepush deployment
+        run: |
+          appcenter codepush deployment add --token "$INPUT_APPCENTER-IOS-API-TOKEN" -a "$INPUT_APPCENTER-IOS-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
+      - name: Create Android codepush deployment
+        run: |
+          appcenter codepush deployment add --token "$INPUT_APPCENTER-ANDROID-API-TOKEN" -a "$INPUT_APPCENTER-ANDROID-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')

--- a/workflows/removeAppCenterDeployments.yml
+++ b/workflows/removeAppCenterDeployments.yml
@@ -1,0 +1,37 @@
+name: remove-app-center-deployments
+run-name: Remove AppCenter deployments for this PR
+
+on:
+  workflow_call:
+
+inputs:
+  appcenter-android-api-token:
+    description: 'AppCenter Android API Token'
+    required: true
+  appcenter-ios-api-token:
+    description: 'AppCenter iOS API Token'
+    required: true
+  appcenter-android-app-name:
+    description: 'AppCenter Android App Name'
+    required: true
+  appcenter-ios-app-name:
+    description: 'AppCenter iOS App Name'
+    required: true
+
+jobs:
+  remove-app-center-deployments:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install -g appcenter-cli
+      - name: Create iOS codepush deployment
+        run: |
+          appcenter codepush deployment remove --token "$INPUT_APPCENTER-IOS-API-TOKEN" -a "$INPUT_APPCENTER-IOS-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
+      - name: Create Android codepush deployment
+        run: |
+          appcenter codepush deployment remove --token "$INPUT_APPCENTER-ANDROID-API-TOKEN" -a "$INPUT_APPCENTER-ANDROID-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')

--- a/workflows/removeAppCenterDeployments.yml
+++ b/workflows/removeAppCenterDeployments.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           node-version: '16'
       - run: npm install -g appcenter-cli
-      - name: Create iOS codepush deployment
+      - name: Remove iOS codepush deployment
         run: |
-          appcenter codepush deployment remove --token "$INPUT_APPCENTER-IOS-API-TOKEN" -a "$INPUT_APPCENTER-IOS-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
-      - name: Create Android codepush deployment
+          appcenter codepush deployment remove --quiet --token "${{ github.event.inputs.appcenter-ios-api-token }}" -a "Ornikar/${{ github.event.inputs.appcenter-ios-app-name }}"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
+      - name: Remove Android codepush deployment
         run: |
-          appcenter codepush deployment remove --token "$INPUT_APPCENTER-ANDROID-API-TOKEN" -a "$INPUT_APPCENTER-ANDROID-APP-NAME"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')
+          appcenter codepush deployment remove --quiet --token "${{ github.event.inputs.appcenter-android-api-token }}" -a "Ornikar/${{ github.event.inputs.appcenter-android-app-name }}"  $(echo "${{ steps.branch-name.outputs.current_branch }}" | sed -r 's/\//_/g')


### PR DESCRIPTION
### Context

 https://ornikar.atlassian.net/browse/INSTRUCTOR-2098

Création de deux workflows permettant la création et la suppression de deployment sur app center. Les workflows prennent en paramètre:
- Les token iOS et Android de l'app
- Les app ID iOS et Android

L'idée est que tous les projets puissent utiliser ces workflows.

Tester avec `act` en local.
